### PR TITLE
Addressed OZ Security audit issue L02

### DIFF
--- a/contracts/BasePool.sol
+++ b/contracts/BasePool.sol
@@ -489,7 +489,7 @@ contract BasePool is Initializable, ReentrancyGuard {
    * @notice Deposits the token balance for this contract as a sponsorship.
    * If people erroneously transfer tokens to this contract, this function will allow us to recoup those tokens as sponsorship.
    */
-  function transferBalanceToSponsorship() public {
+  function transferBalanceToSponsorship() public unlessPaused {
     // Deposit the sponsorship amount
     _depositSponsorshipFrom(address(this), token().balanceOf(address(this)));
   }
@@ -919,12 +919,19 @@ contract BasePool is Initializable, ReentrancyGuard {
     blocklock.unlock(block.number);
   }
 
+  /**
+   * Pauses all deposits into the contract.  This was added so that we can slowly deprecate Pools.  Users can continue
+   * to collect rewards, but eventually the Pool will grow smaller.
+   */
   function pause() public unlessPaused onlyAdmin {
     paused = true;
 
     emit Paused(msg.sender);
   }
 
+  /**
+   * Unpauses all deposits into the contract
+   */
   function unpause() public whenPaused onlyAdmin {
     paused = false;
 

--- a/contracts/BasePool.sol
+++ b/contracts/BasePool.sol
@@ -101,6 +101,35 @@ contract BasePool is Initializable, ReentrancyGuard {
   event Withdrawn(address indexed sender, uint256 amount);
 
   /**
+   * Emitted when a user withdraws their sponsorship and fees from the pool.
+   * @param sender The user that is withdrawing
+   * @param amount The amount they are withdrawing
+   */
+  event SponsorshipAndFeesWithdrawn(address indexed sender, uint256 amount);
+
+  /**
+   * Emitted when a user withdraws from their open deposit.
+   * @param sender The user that is withdrawing
+   * @param amount The amount they are withdrawing
+   */
+  event OpenDepositWithdrawn(address indexed sender, uint256 amount);
+
+  /**
+   * Emitted when a user withdraws from their committed deposit.
+   * @param sender The user that is withdrawing
+   * @param amount The amount they are withdrawing
+   */
+  event CommittedDepositWithdrawn(address indexed sender, uint256 amount);
+
+  /**
+   * Emitted when an address collects a fee
+   * @param sender The address collecting the fee
+   * @param amount The fee amount
+   * @param drawId The draw from which the fee was awarded
+   */
+  event FeeCollected(address indexed sender, uint256 amount, uint256 drawId);
+
+  /**
    * Emitted when a new draw is opened for deposit.
    * @param drawId The draw id
    * @param feeBeneficiary The fee beneficiary for this draw
@@ -290,6 +319,9 @@ contract BasePool is Initializable, ReentrancyGuard {
   function emitCommitted() internal {
     uint256 drawId = currentOpenDrawId();
     emit Committed(drawId);
+    if (address(poolToken) != address(0)) {
+      poolToken.poolMint(openSupply());
+    }
   }
 
   /**
@@ -394,13 +426,14 @@ contract BasePool is Initializable, ReentrancyGuard {
       netWinnings,
       fee
     );
+    emit FeeCollected(draw.feeBeneficiary, fee, drawId);
   }
 
   function awardWinnings(address winner, uint256 amount) internal {
     // Update balance of the winner
     balances[winner] = balances[winner].add(amount);
 
-    // Enter their winnings into the next draw
+    // Enter their winnings into the open draw
     drawState.deposit(winner, amount);
   }
 
@@ -517,29 +550,101 @@ contract BasePool is Initializable, ReentrancyGuard {
    */
   function withdraw() public nonReentrant notLocked {
     uint balance = balances[msg.sender];
-
     // Update their chances of winning
     drawState.withdraw(msg.sender);
-
     _withdraw(msg.sender, balance);
+
+    uint256 sponsorshipAndFees = sponsorshipAndFeeBalanceOf(msg.sender);
+    uint256 openBalance = drawState.openBalanceOf(msg.sender);
+    uint256 committedBalance = drawState.committedBalanceOf(msg.sender);
+
+    if (address(poolToken) != address(0)) {
+      poolToken.poolBurn(msg.sender, committedBalance);
+    }
+
+    emit SponsorshipAndFeesWithdrawn(msg.sender, sponsorshipAndFees);
+    emit OpenDepositWithdrawn(msg.sender, openBalance);
+    emit CommittedDepositWithdrawn(msg.sender, committedBalance);
+    emit Withdrawn(msg.sender, balance);
   }
 
-  function withdrawCommitted(
+  /**
+   * Withdraws only from the sender's sponsorship and fee balances
+   * @param _amount The amount to withdraw
+   */
+  function withdrawSponsorshipAndFee(uint256 _amount) public {
+    uint256 sponsorshipAndFees = sponsorshipAndFeeBalanceOf(msg.sender);
+    require(_amount <= sponsorshipAndFees, "Pool/exceeds-sfee");
+    _withdraw(msg.sender, _amount);
+
+    emit SponsorshipAndFeesWithdrawn(msg.sender, _amount);
+  }
+
+  /**
+   * Returns the total balance of the users sponsorship and fees
+   * @param _sender The user whose balance should be returned
+   */
+  function sponsorshipAndFeeBalanceOf(address _sender) public view returns (uint256) {
+    return balances[_sender] - drawState.balanceOf(_sender);
+  }
+
+  /**
+   * Withdraws from the users open deposits
+   * @param _amount The amount to withdraw
+   */
+  function withdrawOpenDeposit(uint256 _amount) public {
+    drawState.withdrawOpen(msg.sender, _amount);
+    _withdraw(msg.sender, _amount);
+
+    emit OpenDepositWithdrawn(msg.sender, _amount);
+  }
+
+  /**
+   * Withdraws from the users committed deposits
+   * @param _amount The amount to withdraw
+   */
+  function withdrawCommittedDeposit(uint256 _amount) external notLocked returns (bool)  {
+    _withdrawCommittedDepositAndEmit(msg.sender, _amount);
+    if (address(poolToken) != address(0)) {
+      poolToken.poolBurn(msg.sender, _amount);
+    }
+    return true;
+  }
+
+  /**
+   * Allows the associated PoolToken to withdraw for a user; useful when redeeming through the token.
+   * @param _from The user to withdraw from
+   * @param _amount The amount to withdraw
+   */
+  function withdrawCommittedDeposit(
     address _from,
     uint256 _amount
-  ) external onlyToken onlyCommittedBalanceGteq(_from, _amount) returns (bool)  {
-    // Update state variables
+  ) external onlyToken notLocked returns (bool)  {
+    return _withdrawCommittedDepositAndEmit(_from, _amount);
+  }
+
+  /**
+   * A function that withdraws committed deposits for a user and emit the corresponding events.
+   * @param _from User to withdraw for
+   * @param _amount The amount to withdraw
+   */
+  function _withdrawCommittedDepositAndEmit(address _from, uint256 _amount) internal returns (bool) {
     drawState.withdrawCommitted(_from, _amount);
     _withdraw(_from, _amount);
+
+    emit CommittedDepositWithdrawn(_from, _amount);
 
     return true;
   }
 
+  /**
+   * Allows the associated PoolToken to move committed tokens from one user to another.
+   */
   function moveCommitted(
     address _from,
     address _to,
     uint256 _amount
-  ) external onlyToken onlyCommittedBalanceGteq(_from, _amount) returns (bool) {
+  ) external onlyToken onlyCommittedBalanceGteq(_from, _amount) notLocked returns (bool) {
     balances[_from] = balances[_from].sub(_amount, "move could not sub amount");
     balances[_to] = balances[_to].add(_amount);
     drawState.withdrawCommitted(_from, _amount);
@@ -565,8 +670,6 @@ contract BasePool is Initializable, ReentrancyGuard {
     // Withdraw from Compound and transfer
     require(cToken.redeemUnderlying(_amount) == 0, "could not redeem from compound");
     require(token().transfer(_sender, _amount), "could not transfer winnings");
-
-    emit Withdrawn(_sender, _amount);
   }
 
   /**
@@ -801,10 +904,17 @@ contract BasePool is Initializable, ReentrancyGuard {
     return cToken.balanceOfUnderlying(address(this));
   }
 
+  /**
+   * @notice Locks the movement of tokens (essentially the committed deposits and winnings)
+   * @dev The lock only lasts for a duration of blocks.  The lock cannot be relocked until the cooldown duration completes.
+   */
   function lockTokens() public onlyAdmin {
     blocklock.lock(block.number);
   }
 
+  /**
+   * @notice Unlocks the movement of tokens (essentially the committed deposits)
+   */
   function unlockTokens() public onlyAdmin {
     blocklock.unlock(block.number);
   }

--- a/contracts/DrawManager.sol
+++ b/contracts/DrawManager.sol
@@ -182,6 +182,17 @@ library DrawManager {
         }
     }
 
+    function withdrawOpen(State storage self, address _addr, uint256 _amount) public requireOpenDraw(self) onlyNonZero(_addr) {
+        bytes32 userId = bytes32(uint256(_addr));
+        uint256 openTotal = self.sortitionSumTrees.stakeOf(bytes32(self.openDrawIndex), userId);
+
+        require(_amount <= openTotal, "DrawMan/exceeds-open");
+
+        uint256 remaining = openTotal.sub(_amount);
+
+        drawSet(self, self.openDrawIndex, remaining, _addr);
+    }
+
     /**
      * @notice Withdraw's from a user's committed balance.  Fails if the user attempts to take more than available.
      * @param self The DrawManager state
@@ -309,11 +320,11 @@ library DrawManager {
             // Update the Draw's balance for that address
             self.sortitionSumTrees.set(drawId, _amount, userId);
 
-            // Get the new draw total
-            uint256 newDrawTotal = self.sortitionSumTrees.total(drawId);
-
             // if the draw is committed
             if (_drawIndex != self.openDrawIndex) {
+                // Get the new draw total
+                uint256 newDrawTotal = self.sortitionSumTrees.total(drawId);
+
                 // update the draw in the committed tree
                 self.sortitionSumTrees.set(TREE_OF_DRAWS, newDrawTotal, drawId);
             }

--- a/contracts/MCDAwarePool.sol
+++ b/contracts/MCDAwarePool.sol
@@ -102,7 +102,7 @@ contract MCDAwarePool is BasePool, IERC777Recipient {
     uint256 amount,
     bytes calldata,
     bytes calldata
-  ) external {
+  ) external unlessPaused {
     require(msg.sender == address(saiPoolToken()), "can only receive tokens from Sai Pool Token");
     require(address(token()) == address(daiToken()), "contract does not use Dai");
 

--- a/contracts/RecipientWhitelistPoolToken.sol
+++ b/contracts/RecipientWhitelistPoolToken.sol
@@ -62,10 +62,7 @@ contract RecipientWhitelistPoolToken is PoolToken {
       if (_recipientWhitelistEnabled) {
         require(to == address(0) || _recipientWhitelist[to], "recipient is not whitelisted");
       }
-      address implementer = ERC1820_REGISTRY.getInterfaceImplementer(from, TOKENS_SENDER_INTERFACE_HASH);
-      if (implementer != address(0)) {
-          IERC777Sender(implementer).tokensToSend(operator, from, to, amount, userData, operatorData);
-      }
+      super._callTokensToSend(operator, from, to, amount, userData, operatorData);
   }
 
   modifier onlyAdmin() {

--- a/contracts/test/ExposedDrawManager.sol
+++ b/contracts/test/ExposedDrawManager.sol
@@ -41,6 +41,10 @@ contract ExposedDrawManager {
       state.withdraw(user);
     }
 
+    function withdrawOpen(address user, uint256 amount) public {
+      state.withdrawOpen(user, amount);
+    }
+
     function withdrawCommitted(address user, uint256 amount) public {
       state.withdrawCommitted(user, amount);
     }

--- a/test/DrawManager.test.js
+++ b/test/DrawManager.test.js
@@ -252,6 +252,42 @@ contract('DrawManager', (accounts) => {
         })
     })
 
+    describe('withdrawOpen()', () => {
+        it('should now allow a user to withdraw more', async () => {
+            await chai.assert.isRejected(drawManager.withdrawOpen(user1, toWei('10.00001')), /there is no open draw/)
+        })
+
+        describe('with open draw', () => {
+            beforeEach(async () => {
+                await drawManager.openNextDraw()
+                await drawManager.deposit(user1, toWei('10'))
+            })
+
+            it('should do nothing if the user does not exist', async () => {
+                await drawManager.withdrawOpen(user2, toWei('0'))
+            })
+
+            it('should not allow withdrawing from the zero address', async () => {
+                await chai.assert.isRejected(drawManager.withdrawOpen(ZERO_ADDRESS, toWei('5')), /address cannot be zero/)
+            })
+        
+            it('should allow a user to partially withdraw', async () => {
+                assert.equal(await drawManager.openBalanceOf(user1), toWei('10'))
+                await drawManager.withdrawOpen(user1, toWei('5'))
+                assert.equal(await drawManager.openBalanceOf(user1), toWei('5'))
+            })
+    
+            it('should allow a user to partially withdraw', async () => {
+                await drawManager.withdrawOpen(user1, toWei('10'))
+                assert.equal(await drawManager.openBalanceOf(user1), toWei('0'))
+            })
+    
+            it('should now allow a user to withdraw more', async () => {
+                await chai.assert.isRejected(drawManager.withdrawOpen(user1, toWei('10.00001')), /DrawMan\/exceeds-open/)
+            })
+        })
+    })
+
     describe('withdrawCommitted()', () => {
         beforeEach(async () => {
             await drawManager.openNextDraw()

--- a/test/MCDAwarePool.test.js
+++ b/test/MCDAwarePool.test.js
@@ -97,6 +97,16 @@ contract('MCDAwarePool', (accounts) => {
         assert.equal(await receivingPool.openBalanceOf(owner), toWei('10'))
       })
 
+      describe('when paused', async () => {
+        beforeEach(async () => {
+          await receivingPool.pause()
+        })
+
+        it('should reject the migration', async () => {
+          await chai.assert.isRejected(sendingToken.transfer(receivingPool.address, amount), /contract is paused/)
+        })
+      })
+
       describe('to a non-Dai MCD Pool', () => {
         let newDaiToken
 

--- a/test/PoolToken.test.js
+++ b/test/PoolToken.test.js
@@ -215,6 +215,11 @@ contract('PoolToken', (accounts) => {
     })
 
     describe('transfer()', () => {
+      it('should fail when the pool is locked', async () => {
+        await pool.lockTokens()
+        await chai.assert.isRejected(poolToken.transfer(user2, toWei('10')), /PoolToken\/is-locked/)
+      })
+
       it('should transfer tokens to another user', async () => {
         await poolContext.depositPool(toWei('10'))
         await poolContext.nextDraw()

--- a/test/helpers/PoolContext.js
+++ b/test/helpers/PoolContext.js
@@ -133,7 +133,9 @@ module.exports = function PoolContext({ web3, artifacts, accounts }) {
       logs = (await pool.rewardAndOpenNextDraw(SECRET_HASH, SECRET, SALT)).logs;
     }
 
-    const [Rewarded, Committed, Opened] = logs
+    // console.log(logs.map(log => log.event))
+
+    const [Rewarded, FeeCollected, Committed, Opened] = logs
 
     debug('rewardAndOpenNextDraw: ', logs)
     assert.equal(Opened.event, "Opened")


### PR DESCRIPTION
L02: Only direct deposits are pausable

Mitigation:

- Added documentation to the pause() and unpause() function stating that
  the intention is to pause only deposits so that the contract can
slowly be deprecated
- Added `unlessPaused` to MCDAwarePool to prevent token migrations to
  paused contracts