### PR TITLE
Addressed OZ Security audit issue L02

### DIFF
--- a/contracts/BasePool.sol
+++ b/contracts/BasePool.sol
@@ -489,7 +489,7 @@ contract BasePool is Initializable, ReentrancyGuard {
    * @notice Deposits the token balance for this contract as a sponsorship.
    * If people erroneously transfer tokens to this contract, this function will allow us to recoup those tokens as sponsorship.
    */
-  function transferBalanceToSponsorship() public {
+  function transferBalanceToSponsorship() public unlessPaused {
     // Deposit the sponsorship amount
     _depositSponsorshipFrom(address(this), token().balanceOf(address(this)));
   }
@@ -919,12 +919,19 @@ contract BasePool is Initializable, ReentrancyGuard {
     blocklock.unlock(block.number);
   }
 
+  /**
+   * Pauses all deposits into the contract.  This was added so that we can slowly deprecate Pools.  Users can continue
+   * to collect rewards, but eventually the Pool will grow smaller.
+   */
   function pause() public unlessPaused onlyAdmin {
     paused = true;
 
     emit Paused(msg.sender);
   }
 
+  /**
+   * Unpauses all deposits into the contract
+   */
   function unpause() public whenPaused onlyAdmin {
     paused = false;
 

--- a/contracts/MCDAwarePool.sol
+++ b/contracts/MCDAwarePool.sol
@@ -102,7 +102,7 @@ contract MCDAwarePool is BasePool, IERC777Recipient {
     uint256 amount,
     bytes calldata,
     bytes calldata
-  ) external {
+  ) external unlessPaused {
     require(msg.sender == address(saiPoolToken()), "can only receive tokens from Sai Pool Token");
     require(address(token()) == address(daiToken()), "contract does not use Dai");
 

--- a/test/MCDAwarePool.test.js
+++ b/test/MCDAwarePool.test.js
@@ -97,6 +97,16 @@ contract('MCDAwarePool', (accounts) => {
         assert.equal(await receivingPool.openBalanceOf(owner), toWei('10'))
       })
 
+      describe('when paused', async () => {
+        beforeEach(async () => {
+          await receivingPool.pause()
+        })
+
+        it('should reject the migration', async () => {
+          await chai.assert.isRejected(sendingToken.transfer(receivingPool.address, amount), /contract is paused/)
+        })
+      })
+
       describe('to a non-Dai MCD Pool', () => {
         let newDaiToken
 


### PR DESCRIPTION
L02: Only direct deposits are pausable

Mitigation:

- Added documentation to the pause() and unpause() function stating that
  the intention is to pause only deposits so that the contract can
slowly be deprecated
- Added `unlessPaused` to MCDAwarePool to prevent token migrations to
  paused contracts