### PR TITLE
Fixes OpenZeppelin security issue L06

### DIFF
--- a/contracts/Blocklock.sol
+++ b/contracts/Blocklock.sol
@@ -1,7 +1,10 @@
 pragma solidity ^0.5.12;
 
 /**
- * Implements a "lock" feature with a cooldown
+ * @title Blocklock
+ * @author Brendan Asselstine
+ * @notice A time lock with a cooldown period.  When locked, the contract will remain locked until it is unlocked manually
+ * or the lock duration expires.  After the contract is unlocked, it cannot be locked until the cooldown duration expires.
  */
 library Blocklock {
 
@@ -12,15 +15,31 @@ library Blocklock {
     uint256 cooldownDuration;
   }
 
+  /**
+   * @notice Sets the duration of the lock.  This how long the lock lasts before it expires and automatically unlocks.
+   * @param self The Blocklock state
+   * @param lockDuration The duration, in blocks, that the lock should last.
+   */
   function setLockDuration(State storage self, uint256 lockDuration) public {
     require(lockDuration > 0, "Blocklock/lock-min");
     self.lockDuration = lockDuration;
   }
 
+  /**
+   * @notice Sets the cooldown duration in blocks.  This is the number of blocks that must pass before being able to
+   * lock again.  The cooldown duration begins when the lock duration expires, or when it is unlocked manually.
+   * @param self The Blocklock state
+   * @param cooldownDuration The duration of the cooldown, in blocks.
+   */
   function setCooldownDuration(State storage self, uint256 cooldownDuration) public {
     self.cooldownDuration = cooldownDuration;
   }
 
+  /**
+   * @notice Returns whether the state is locked at the given block number.
+   * @param self The Blocklock state
+   * @param blockNumber The current block number.
+   */
   function isLocked(State storage self, uint256 blockNumber) public view returns (bool) {
     uint256 lockEndAt = self.lockedAt + self.lockDuration;
     // if we unlocked early
@@ -34,15 +53,31 @@ library Blocklock {
     );
   }
 
+  /**
+   * @notice Locks the state at the given block number.
+   * @param self The Blocklock state
+   * @param blockNumber The block number to use as the lock start time
+   */
   function lock(State storage self, uint256 blockNumber) public {
     require(canLock(self, blockNumber), "Blocklock/no-lock");
     self.lockedAt = blockNumber;
   }
 
+  /**
+   * @notice Manually unlocks the lock.
+   * @param self The Blocklock state
+   * @param blockNumber The block number at which the lock is being unlocked.
+   */
   function unlock(State storage self, uint256 blockNumber) public {
     self.unlockedAt = blockNumber;
   }
 
+  /**
+   * @notice Returns whether the Blocklock can be locked at the given block number
+   * @param self The Blocklock state
+   * @param blockNumber The block number to check against
+   * @return True if we can lock at the given block number, false otherwise.
+   */
   function canLock(State storage self, uint256 blockNumber) public view returns (bool) {
     return (
       self.lockedAt == 0 ||

--- a/contracts/DrawManager.sol
+++ b/contracts/DrawManager.sol
@@ -41,7 +41,7 @@ library DrawManager {
      */
     bytes32 public constant TREE_OF_DRAWS = "TreeOfDraws";
 
-    uint8 public constant MAX_LEAVES = 10;
+    uint8 public constant MAX_BRANCHES_PER_NODE = 10;
 
     /**
      * Stores information for all draws.
@@ -87,7 +87,7 @@ library DrawManager {
     function openNextDraw(State storage self) public returns (uint256) {
         if (self.openDrawIndex == 0) {
             // If there is no previous draw, we must initialize
-            self.sortitionSumTrees.createTree(TREE_OF_DRAWS, MAX_LEAVES);
+            self.sortitionSumTrees.createTree(TREE_OF_DRAWS, MAX_BRANCHES_PER_NODE);
         } else {
             // else add current draw to sortition sum trees
             bytes32 drawId = bytes32(self.openDrawIndex);
@@ -96,7 +96,7 @@ library DrawManager {
         }
         // now create a new draw
         uint256 drawIndex = self.openDrawIndex.add(1);
-        self.sortitionSumTrees.createTree(bytes32(drawIndex), MAX_LEAVES);
+        self.sortitionSumTrees.createTree(bytes32(drawIndex), MAX_BRANCHES_PER_NODE);
         self.openDrawIndex = drawIndex;
 
         return drawIndex;
@@ -332,7 +332,8 @@ library DrawManager {
     }
 
    /**
-     * @notice Selects an address by indexing into the committed tokens using the passed token
+     * @notice Selects an address by indexing into the committed tokens using the passed token.
+     * If there is no committed supply, the zero address is returned.
      * @param self The DrawManager state
      * @param _token The token index to select
      * @return The selected address

--- a/contracts/MCDAwarePool.sol
+++ b/contracts/MCDAwarePool.sol
@@ -123,6 +123,10 @@ contract MCDAwarePool is BasePool, IERC777Recipient {
     }
   }
 
+  /**
+   * @notice Returns the address of the PoolSai pool token contract
+   * @return The address of the Sai PoolToken contract
+   */
   function saiPoolToken() internal view returns (PoolToken) {
     if (address(saiPool()) != address(0)) {
       return saiPool().poolToken();
@@ -131,10 +135,18 @@ contract MCDAwarePool is BasePool, IERC777Recipient {
     }
   }
 
+  /**
+   * @notice Returns the address of the Sai token
+   * @return The address of the sai token
+   */
   function saiToken() internal returns (GemLike) {
     return scdMcdMigration().saiJoin().gem();
   }
 
+  /**
+   * @notice Returns the address of the Dai token
+   * @return The address of the Dai token.
+   */
   function daiToken() internal returns (GemLike) {
     return scdMcdMigration().daiJoin().dai();
   }

--- a/contracts/PoolToken.sol
+++ b/contracts/PoolToken.sol
@@ -86,8 +86,15 @@ contract PoolToken is Initializable, IERC20, IERC777 {
   // ERC20-allowances
   mapping (address => mapping (address => uint256)) internal _allowances;
 
+  // The Pool that is bound to this token
   BasePool internal _pool;
 
+  /**
+   * @notice Initializes the PoolToken.
+   * @param name The name of the token
+   * @param symbol The token symbol
+   * @param defaultOperators The default operators who are allowed to move tokens
+   */
   function init (
     string memory name,
     string memory symbol,
@@ -112,10 +119,19 @@ contract PoolToken is Initializable, IERC20, IERC777 {
       ERC1820_REGISTRY.setInterfaceImplementer(address(this), keccak256("ERC20Token"), address(this));
   }
 
+  /**
+   * @notice Returns the address of the Pool contract
+   * @return The address of the pool contract
+   */
   function pool() public view returns (address) {
       return address(_pool);
   }
 
+  /**
+   * @notice Calls the ERC777 transfer hook, and emits Redeemed and Transfer.  Can only be called by the Pool contract.
+   * @param from The address from which to redeem tokens
+   * @param amount The amount of tokens to redeem
+   */
   function poolRedeem(address from, uint256 amount) external onlyPool {
       _callTokensToSend(from, from, address(0), amount, '', '');
 
@@ -468,6 +484,9 @@ contract PoolToken is Initializable, IERC20, IERC777 {
       emit Transfer(from, address(0), amount);
   }
 
+  /**
+   * @notice Moves tokens from one user to another.  Emits Sent and Transfer events.
+   */
   function _move(
       address operator,
       address from,
@@ -484,6 +503,12 @@ contract PoolToken is Initializable, IERC20, IERC777 {
       emit Transfer(from, to, amount);
   }
 
+  /**
+   * Approves of a token spend by a spender for a holder.
+   * @param holder The address from which the tokens are spent
+   * @param spender The address that is spending the tokens
+   * @param value The amount of tokens to spend
+   */
   function _approve(address holder, address spender, uint256 value) private {
       require(spender != address(0), "ERC777: approve to the zero address");
 
@@ -525,6 +550,7 @@ contract PoolToken is Initializable, IERC20, IERC777 {
     * @param amount uint256 amount of tokens to transfer
     * @param userData bytes extra information provided by the token holder (if any)
     * @param operatorData bytes extra information provided by the operator (if any)
+    * @param requireReceptionAck whether to require that, if the recipient is a contract, it implements IERC777Recipient
     */
   function _callTokensReceived(
       address operator,
@@ -545,11 +571,17 @@ contract PoolToken is Initializable, IERC20, IERC777 {
       }
   }
 
+  /**
+   * @notice Requires the sender to be the pool contract
+   */
   modifier onlyPool() {
     require(msg.sender == address(_pool), "PoolToken/only-pool");
     _;
   }
 
+  /**
+   * @notice Requires the contract to be unlocked
+   */
   modifier notLocked() {
     require(!_pool.isLocked(), "PoolToken/is-locked");
     _;

--- a/contracts/RecipientWhitelistPoolToken.sol
+++ b/contracts/RecipientWhitelistPoolToken.sol
@@ -20,24 +20,73 @@ pragma solidity 0.5.12;
 
 import "./PoolToken.sol";
 
+/**
+ * @title RecipientWhitelistPoolToken
+ * @author Brendan Asselstine
+ * @notice Allows the pool admins to only allow token transfers to particular addresses.
+ */
 contract RecipientWhitelistPoolToken is PoolToken {
+  /**
+   * @notice Whether the whitelist is enabled
+   */
   bool internal _recipientWhitelistEnabled;
+
+  /**
+   * @notice Whether a recipient has been whitelisted
+   */
   mapping(address => bool) internal _recipientWhitelist;
 
+  /**
+   * @notice Emitted when the whitelist is enabled or disabled
+   * @param admin The admin who affected the change.
+   * @param enabled Whether the whitelist was enabled.
+   */
+  event WhitelistEnabled(address indexed admin, bool enabled);
+
+  /**
+   * @notice Emitted when a recipient whitelist status changes.
+   * @param admin The admin who affected the change
+   * @param recipient The recipient whose whitelisting status was changed
+   * @param whitelisted Whether the recipient was whitelisted
+   */
+  event RecipientWhitelisted(address indexed admin, address indexed recipient, bool whitelisted);
+
+  /**
+   * @notice Returns whether the whitelist is enabled.  If enabled, recipients must be whitelisted in order to receive tokens.
+   * Otherwise if the whitelist is not enabled anyone is able to receive tokens.
+   * @return True if whitelist enabled, false otherwise.
+   */
   function recipientWhitelistEnabled() public view returns (bool) {
     return _recipientWhitelistEnabled;
   }
 
+  /**
+   * @notice Checks whether a recipient has been whitelisted.  This is irrespective of whether whitelisting is enabled or not.
+   * @return True if the recipient has been whitelisted, false otherwise.
+   */
   function recipientWhitelisted(address _recipient) public view returns (bool) {
     return _recipientWhitelist[_recipient];
   }
 
+  /**
+   * @notice Sets whether recipient whitelisting is enabled.  Only callable by the Pool admin.
+   * @param _enabled True if whitelisting should be enabled, false otherwise
+   */
   function setRecipientWhitelistEnabled(bool _enabled) public onlyAdmin {
     _recipientWhitelistEnabled = _enabled;
+
+    emit WhitelistEnabled(msg.sender, _enabled);
   }
 
+  /**
+   * @notice Sets whether the recipient should be whitelisted.  Only callable by the Pool admin.
+   * @param _recipient The recipient to whitelist
+   * @param _whitelisted True if the recipient should be whitelisted, false otherwise
+   */
   function setRecipientWhitelisted(address _recipient, bool _whitelisted) public onlyAdmin {
     _recipientWhitelist[_recipient] = _whitelisted;
+
+    emit RecipientWhitelisted(msg.sender, _recipient, _whitelisted);
   }
 
   /**
@@ -65,6 +114,9 @@ contract RecipientWhitelistPoolToken is PoolToken {
       super._callTokensToSend(operator, from, to, amount, userData, operatorData);
   }
 
+  /**
+   * @notice Requires the caller to be the Pool admin
+   */
   modifier onlyAdmin() {
     require(_pool.isAdmin(msg.sender), "WhitelistToken/is-admin");
     _;


### PR DESCRIPTION
L06: Misleading comments and variable names

Added and fixed comments in:
- BasePool
- DrawManager
- PoolToken

TODO:

- [x] RecipientWhitelistPoolToken
- [x] Blocklock
- [x] PoolToken
- [x] MCDAwarePool